### PR TITLE
Fix workflow by adding write permission.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@ name: Publish Notion website to GitHub Pages
 on:
   # Manual update only.
   workflow_dispatch:
+  
+permissions:
+  contents: write
 
 jobs:
   deploy:


### PR DESCRIPTION
Currently the workflow fails at the step where it tries to push generated static pages to the gh-pages branch.
This fix restores the functionality of the workflow.
Tested it, and now workflow completes without any issues.