### PR TITLE
Update to checkout v3 (to use node.js 16 and get rid of a warning)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,12 @@ jobs:
 
     steps:
       - name: Checkout loconotion
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: leoncvlt/loconotion
           path: loconotion
       - name: Checkout this repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: pages_repo
 


### PR DESCRIPTION
Use actions/checkout@v3 instead of v2 to get rid of node version warnings.

Details: the workflow was loggin a warning: 

> deploy
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

I found [this thread](https://github.com/actions/checkout/issues/1047) and found out that bumping the version of checkout to v3 gets rid of this warning.
Tested the workflow after this change and seems to be working just fine, without throwing this warning. 👍 