### PR TITLE
Use chromedriver on agent directly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          GIT_DEPLOY_DIR=dist/site \
+          GIT_DEPLOY_DIR=../dist/site \
           GIT_DEPLOY_BRANCH=gh-pages \
           GIT_DEPLOY_REPO="https://${{ github.token }}@github.com/${{ github.repository }}.git" ./deploy.sh
+        working-directory: pages_repo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout loconotion
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           repository: leoncvlt/loconotion
           path: loconotion
       - name: Checkout this repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           path: pages_repo
       - name: Download and install chromedriver
@@ -26,7 +26,7 @@ jobs:
         run: pip install -r loconotion/requirements.txt
       - name: Run Loconotion
         run: |
-          python3 loconotion/loconotion --chromedriver $(which chromium-chromedriver) "pages_repo/site.toml"
+          python3 loconotion/loconotion --chromedriver chromedriver "pages_repo/site.toml"
       - name: Push to GitHub pages
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,6 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout loconotion
         uses: actions/checkout@v3
@@ -21,23 +20,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: pages_repo
-
-      - name: Build Loconotion docker image
-        run: docker-compose build loconotion
-        working-directory: loconotion
-        
+      - name: Download and install chromedriver
+        run: sudo apt install chromium-chromedriver
+      - name: Install Loconotion dependencies
+        run: pip install -r loconotion/requirements.txt
       - name: Run Loconotion
         run: |
-          docker run \
-          -v "$GITHUB_WORKSPACE/pages_repo/dist:/app/loconotion/dist" \
-          -v "$GITHUB_WORKSPACE/pages_repo/site.toml:/app/loconotion/site.toml" \
-          loconotion "site.toml"
-        working-directory: loconotion
+          python3 loconotion/loconotion --chromedriver $(which chromium-chromedriver) "pages_repo/site.toml"
       - name: Push to GitHub pages
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          
           GIT_DEPLOY_DIR=dist/site \
           GIT_DEPLOY_BRANCH=gh-pages \
           GIT_DEPLOY_REPO="https://${{ github.token }}@github.com/${{ github.repository }}.git" ./deploy.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout loconotion
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: leoncvlt/loconotion
           path: loconotion
       - name: Checkout this repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: pages_repo
       - name: Download and install chromedriver

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,4 +34,3 @@ jobs:
           GIT_DEPLOY_DIR=dist/site \
           GIT_DEPLOY_BRANCH=gh-pages \
           GIT_DEPLOY_REPO="https://${{ github.token }}@github.com/${{ github.repository }}.git" ./deploy.sh
-        working-directory: pages_repo


### PR DESCRIPTION
Simplifies things and means we don't rely on the Loconotion Dockerfile (which is now using an outdated version of the chromedriver)

Fixes https://github.com/timovv/notion-website-template/issues/14